### PR TITLE
Remove NaMaster from the dependency list.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dependencies = [
     'iminuit',
     'pandas',
     'progressbar',
-    'pymaster',
     'pyoperators[fft]>=0.13.18',
     'pysimulators>=1.2.3',
     'pysm3',


### PR DESCRIPTION
The NaMaster package can not be installed automatically, its dependencies (such as numpy or required binary libraries) need to be installed beforehand. This package needs to be installed independently from qubic.