### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     'corner',
     'emcee',
     'GetDist',
-    'healpy>=0.6.1',
+    'healpy',
     'iminuit',
     'pandas',
     'progressbar',


### PR DESCRIPTION
Remove requirement for the healpy version. Conda on Ventura installs the latest healpy version but it appears as 0.0.0 and is then ignored by the package builder, which tries to re-install it (and currently fails to do so).